### PR TITLE
Changes to Linux platform settings

### DIFF
--- a/Materials/platforms/inweb-on-linux.mk
+++ b/Materials/platforms/inweb-on-linux.mk
@@ -12,7 +12,8 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX -fdiagnostics-color=auto -O2
+CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX \
+	-fdiagnostics-color=auto $(CFLAGS)
 
 MANYWARNINGS = -Wall -Wextra -Wimplicit-fallthrough=2 -Wno-pointer-to-int-cast \
     -Wno-unknown-pragmas -Wno-unused-but-set-parameter \
@@ -69,7 +70,7 @@ safe:
 
 define make-me-once-tangled
 	gcc -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
-	gcc $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o  -lm
+	gcc $(CCOPTS) -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o  -lm -pthread $(LDFLAGS)
 endef
 
 define make-me

--- a/Materials/platforms/linux.mk
+++ b/Materials/platforms/linux.mk
@@ -12,7 +12,8 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX -fdiagnostics-color=auto -O2
+CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX \
+	-fdiagnostics-color=auto $(CFLAGS)
 
 MANYWARNINGS = -Wall -Wextra -Wimplicit-fallthrough=2 -Wno-pointer-to-int-cast \
     -Wno-unknown-pragmas -Wno-unused-but-set-parameter \

--- a/Materials/platforms/linux.mkscript
+++ b/Materials/platforms/linux.mkscript
@@ -73,15 +73,17 @@ INWEB = inweb/Tangled/inweb
 {end-define}
 
 {define: link to: TO from: FROM ?options: OPTS}
-	gcc $(CCOPTS) -g -o {TO} {FROM} {OPTS} -lm
+	gcc $(CCOPTS) -o {TO} {FROM} {OPTS} -lm -pthread $(LDFLAGS)
 {end-define}
 
 # Where:
 
-# Basic options; color error messages and optimization; _POSIX_C_SOURCE is
-# necessary for readlink().
+# Source options (_POSIX_C_SOURCE is necessary for readlink()); color error
+# messages; pull in optimization and debug flags from whatever is defined in the
+# CFLAGS and LDFLAGS environment variables by the Linux packaging config.
 
-CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX -fdiagnostics-color=auto -O2
+CCOPTS = -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -DPLATFORM_LINUX \
+	-fdiagnostics-color=auto $(CFLAGS)
 
 MANYWARNINGS = -Wall -Wextra -Wimplicit-fallthrough=2 -Wno-pointer-to-int-cast \
     -Wno-unknown-pragmas -Wno-unused-but-set-parameter \


### PR DESCRIPTION
I've decided to make some adjustments to the platform settings after
trying to build RPM, DEB, and Flatpak packages. The various packaging
tools rely on being able to set their own optimization, debugging, and
hardening flags via the CFLAGS and LDFLAGS environment variables, so this
brings in that capability.

Additionally, building in a Flatpak environment requires explicitly
linking with the -pthread flag. I'm not sure why this was implicit before,
but I've added it to the linker macro, as it doesn't hurt to specify it
explicitly in any case.