### PR TITLE
Use Xcode Command Line Tools instead of Xcode.app

### DIFF
--- a/Materials/platforms/inweb-on-macos.mk
+++ b/Materials/platforms/inweb-on-macos.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macos32.mk
+++ b/Materials/platforms/inweb-on-macos32.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macosarm.mk
+++ b/Materials/platforms/inweb-on-macosarm.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macosuniv.mk
+++ b/Materials/platforms/inweb-on-macosuniv.mk
@@ -12,8 +12,8 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macos.mk
+++ b/Materials/platforms/macos.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/macos.mkscript
+++ b/Materials/platforms/macos.mkscript
@@ -77,7 +77,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/macos32.mk
+++ b/Materials/platforms/macos32.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/macos32.mkscript
+++ b/Materials/platforms/macos32.mkscript
@@ -81,7 +81,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/macosarm.mk
+++ b/Materials/platforms/macosarm.mk
@@ -12,7 +12,7 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosarm.mkscript
+++ b/Materials/platforms/macosarm.mkscript
@@ -77,7 +77,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosuniv.mk
+++ b/Materials/platforms/macosuniv.mk
@@ -12,8 +12,8 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosuniv.mkscript
+++ b/Materials/platforms/macosuniv.mkscript
@@ -81,8 +81,8 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 


### PR DESCRIPTION
I'm honestly not super familiar with this side of clang, but my rough understanding is that the Xcode command line tools are a much smaller download, much more likely to be installed on most systems, and they're the appropriate dependency for most projects that don't use Xcode. I had a hard time getting the package to build because I had the command line tools installed, but have never downloaded Xcode. Installing the command line tools are a prerequisite for having Xcode.app installed, so this shouldn't break anyone who's currently using Xcode.app, but it saves anyone else who wants to build the project, like me, a very long Xcode.app download.

tested locally with the `macos` platform and works for me. I haven't tested the other macos platforms but I have no reason to believe they would differ.