### PR TITLE
Use $(CC) as the compiler on Linux.

### DIFF
--- a/Materials/platforms/inweb-on-linux.mk
+++ b/Materials/platforms/inweb-on-linux.mk
@@ -73,8 +73,8 @@ safe:
 	$(call make-me-using-safety-copy)
 
 define make-me-once-tangled
-	gcc -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
-	gcc $(CCOPTS) -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o  -lm -pthread $(LDFLAGS)
+	$(CC) -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
+	$(CC) $(CCOPTS) -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o  -lm -pthread $(LDFLAGS)
 endef
 
 define make-me

--- a/Materials/platforms/linux.mkscript
+++ b/Materials/platforms/linux.mkscript
@@ -65,15 +65,15 @@ INWEB = inweb/Tangled/inweb
 # and one for linking those *.o files into an executable.
 
 {define: compile to: TO from: FROM ?options: OPTS}
-	gcc -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
+	$(CC) -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
 {end-define}
 
 {define: compile-indulgently to: TO from: FROM ?options: OPTS}
-	gcc -std=c99 -c $(FEWERWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
+	$(CC) -std=c99 -c $(FEWERWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
 {end-define}
 
 {define: link to: TO from: FROM ?options: OPTS}
-	gcc $(CCOPTS) -o {TO} {FROM} {OPTS} -lm -pthread $(LDFLAGS)
+	$(CC) $(CCOPTS) -o {TO} {FROM} {OPTS} -lm -pthread $(LDFLAGS)
 {end-define}
 
 # Where:


### PR DESCRIPTION
While other platforms may have a standard compiler that can be hardcoded, Linux systems may want to switch between gcc and clang, or even a wrapper script for producing portable static binaries like musl-gcc.

Using the standard $(CC) variable for the compiler name makes it easy to override the compiler choice without having to modify makefiles.