### PR TITLE
Update CSS for printability

### DIFF
--- a/Patterns/HTML/Base/Base.css
+++ b/Patterns/HTML/Base/Base.css
@@ -25,8 +25,15 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
-a.function-link:link, a.function-link:visited {
-	text-decoration: black solid underline;
+@media screen {
+	a.function-link:link, a.function-link:visited {
+		text-decoration: black solid underline;
+	}
+}
+@media print {
+	a.function-link {
+		text-decoration: none;
+	}
 }
 a.function-link:active, a.function-link:hover {
 	font-weight: 700

--- a/Patterns/HTML/Base/Navigation.css
+++ b/Patterns/HTML/Base/Navigation.css
@@ -133,11 +133,19 @@ nav[role="navigation"] h1 {
     margin-top: 0em
 }
 
-main {
-    max-width: 1024px;
-    min-width: 320px;
-    margin-left: 250px;
-    min-height: 100%;
-    height: auto !important;
-    height: 100%
+@media screen {
+	main {
+		max-width: 1024px;
+		min-width: 320px;
+		margin-left: 250px;
+		min-height: 100%;
+		height: auto !important;
+		height: 100%
+	}
+}
+
+@media print {
+	nav[role="navigation"] {
+		display: none;
+	}
 }

--- a/Patterns/HTML/Base/Progress.css
+++ b/Patterns/HTML/Base/Progress.css
@@ -104,3 +104,9 @@ nav[role="progress"] ul li a:active {
 nav[role="progress"] ul li a:hover {
     color: #dd2c0d
 }
+
+@media print {
+	nav[role="progress"] {
+		display: none;
+	}
+}

--- a/Patterns/HTML/Breadcrumbs/Breadcrumbs.css
+++ b/Patterns/HTML/Breadcrumbs/Breadcrumbs.css
@@ -6,6 +6,12 @@ div.breadcrumbs {
 	padding-bottom: 4px;
 }
 
+@media print {
+	div.breadcrumbs {
+		position: static;
+	}
+}
+
 .crumbs {
 	border:1px solid #dedede;
 	height:3em;

--- a/Patterns/HTML/Popups/Popups.css
+++ b/Patterns/HTML/Popups/Popups.css
@@ -9,6 +9,12 @@
   user-select: none;
 }
 
+@media print {
+	.popup {
+		display: none;
+	}
+}
+
 /* The actual popup */
 .popup .popuptext {
   visibility: hidden;


### PR DESCRIPTION
Currently, the page layout can get somewhat messed up when attempting to print inweb's HTML pages:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/12954162/166217724-7878254d-f177-4647-8ab1-69a1cc9e62ec.png">

The proposed change would hide the left and bottom navigation bars, fix the top navigation top the very top, and allow the main content to take up the entire width of the page. The question mark buttons and link underlines on function names are also hidden. (For printing only -- screen display is unaffected.)