### PR TITLE
Use xcrun to determine the SDK path

### DIFF
--- a/Materials/platforms/inweb-on-macos.mk
+++ b/Materials/platforms/inweb-on-macos.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macos32.mk
+++ b/Materials/platforms/inweb-on-macos32.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macosarm.mk
+++ b/Materials/platforms/inweb-on-macosarm.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-macosuniv.mk
+++ b/Materials/platforms/inweb-on-macosuniv.mk
@@ -12,8 +12,10 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/inweb-on-windows.mk
+++ b/Materials/platforms/inweb-on-windows.mk
@@ -70,7 +70,7 @@ safe:
 
 define make-me-once-tangled
 	x86_64-w64-mingw32-clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
-	x86_64-w64-mingw32-clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o -lshlwapi 
+	x86_64-w64-mingw32-clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o 
 endef
 
 define make-me

--- a/Materials/platforms/inweb-on-windows.mk
+++ b/Materials/platforms/inweb-on-windows.mk
@@ -70,7 +70,7 @@ safe:
 
 define make-me-once-tangled
 	x86_64-w64-mingw32-clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
-	x86_64-w64-mingw32-clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o 
+	x86_64-w64-mingw32-clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o -lshlwapi 
 endef
 
 define make-me

--- a/Materials/platforms/macos.mk
+++ b/Materials/platforms/macos.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/macos.mkscript
+++ b/Materials/platforms/macos.mkscript
@@ -59,6 +59,12 @@ INWEB = inweb/Tangled/inweb
 
 # -----------------------------------------------------------------------------
 
+# Request the path of MacOSX.sdk:
+
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+# -----------------------------------------------------------------------------
+
 # Now three macro definitions: two for compiling C code to *.o object files
 # (one being strict about warnings, the other indulgently suppressing them);
 # and one for linking those *.o files into an executable.
@@ -77,7 +83,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
 

--- a/Materials/platforms/macos32.mk
+++ b/Materials/platforms/macos32.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/macos32.mkscript
+++ b/Materials/platforms/macos32.mkscript
@@ -63,6 +63,12 @@ INWEB = inweb/Tangled/inweb
 
 # -----------------------------------------------------------------------------
 
+# Request the path of MacOSX.sdk:
+
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+# -----------------------------------------------------------------------------
+
 # Now three macro definitions: two for compiling C code to *.o object files
 # (one being strict about warnings, the other indulgently suppressing them);
 # and one for linking those *.o files into an executable.
@@ -81,7 +87,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.4 -arch i386 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -ferror-limit=1000
 

--- a/Materials/platforms/macosarm.mk
+++ b/Materials/platforms/macosarm.mk
@@ -12,7 +12,9 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosarm.mkscript
+++ b/Materials/platforms/macosarm.mkscript
@@ -59,6 +59,12 @@ INWEB = inweb/Tangled/inweb
 
 # -----------------------------------------------------------------------------
 
+# Request the path of MacOSX.sdk:
+
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+# -----------------------------------------------------------------------------
+
 # Now three macro definitions: two for compiling C code to *.o object files
 # (one being strict about warnings, the other indulgently suppressing them);
 # and one for linking those *.o files into an executable.
@@ -77,7 +83,7 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosuniv.mk
+++ b/Materials/platforms/macosuniv.mk
@@ -12,8 +12,10 @@ EXEEXTENSION =
 INTEST = intest/Tangled/intest
 INWEB = inweb/Tangled/inweb
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 

--- a/Materials/platforms/macosuniv.mkscript
+++ b/Materials/platforms/macosuniv.mkscript
@@ -59,6 +59,12 @@ INWEB = inweb/Tangled/inweb
 
 # -----------------------------------------------------------------------------
 
+# Request the path of MacOSX.sdk:
+
+SDKPATH := $(shell xcrun -show-sdk-path)
+
+# -----------------------------------------------------------------------------
+
 # Now three macro definitions: two for compiling C code to *.o object files
 # (one being strict about warnings, the other indulgently suppressing them);
 # and one for linking those *.o files into an executable.
@@ -81,8 +87,8 @@ INWEB = inweb/Tangled/inweb
 
 # Where:
 
-CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
-CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk $(CFLAGS)
+CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
+CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
 MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
 


### PR DESCRIPTION
An early change (https://github.com/ganelson/inweb/pull/7/files) had to do with changing the hardwired Xcode path to a hardwired CommandLineTools path. This isn't really better; you're supposed to do

    xcrun -show-sdk-path

to determine the path. This allows for installing multiple SDKs on a single Mac, for example. This change does that.

I'm using the GNU Make `$(shell)` feature, which should be fine on all MacOS. The only hitch is that it's a shell command every time the Makefile is parsed. I don't think this is a big total, but I'm not familiar with what's going on under the hood. (Particularly in the big Inform test suite.)

