### PR TITLE
Fix for carousel selection issue.

### DIFF
--- a/docs/docs-assets/Carousel.css
+++ b/docs/docs-assets/Carousel.css
@@ -22,6 +22,9 @@
   transition: 0.6s ease;
   border-radius: 0 3px 3px 0;
   user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
 }
 
 /* Position the "next button" to the right */


### PR DESCRIPTION
The image carousel had an annoying feature of selecting part of the page around itself when clicking on the next / previous buttons. This change fixes the issue.