### PR TITLE
More mac warnings

### DIFF
--- a/Materials/platforms/inweb-on-macos.mk
+++ b/Materials/platforms/inweb-on-macos.mk
@@ -16,7 +16,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/Materials/platforms/inweb-on-macosarm.mk
+++ b/Materials/platforms/inweb-on-macosarm.mk
@@ -16,7 +16,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable
 

--- a/Materials/platforms/inweb-on-macosuniv.mk
+++ b/Materials/platforms/inweb-on-macosuniv.mk
@@ -17,7 +17,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
 CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable
 
@@ -72,11 +72,11 @@ safe:
 	$(call make-me-using-safety-copy)
 
 define make-me-once-tangled
-	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTSX) -g  -o $(ME)/Tangled/$(ME)_x86.o $(ME)/Tangled/$(ME).c
-	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTSA) -g  -o $(ME)/Tangled/$(ME)_arm.o $(ME)/Tangled/$(ME).c
-	clang $(CCOPTSX) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION)_x86 $(ME)/Tangled/$(ME)_x86.o 
-	clang $(CCOPTSA) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION)_arm $(ME)/Tangled/$(ME)_arm.o 
-	lipo -create -output $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME)$(EXEEXTENSION)_x86 $(ME)/Tangled/$(ME)$(EXEEXTENSION)_arm
+	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTSX) -g  -o $(ME)/Tangled/$(ME)_x86.o  $(ME)/Tangled/$(ME).c
+	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTSA) -g  -o $(ME)/Tangled/$(ME)_arm.o  $(ME)/Tangled/$(ME).c
+	clang $(CCOPTSX) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION)_x86  $(ME)/Tangled/$(ME)_x86.o  
+	clang $(CCOPTSA) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION)_arm  $(ME)/Tangled/$(ME)_arm.o  
+	lipo -create -output $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME)$(EXEEXTENSION)_x86  $(ME)/Tangled/$(ME)$(EXEEXTENSION)_arm 
 endef
 
 define make-me

--- a/Materials/platforms/macos.mk
+++ b/Materials/platforms/macos.mk
@@ -16,7 +16,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/Materials/platforms/macos.mkscript
+++ b/Materials/platforms/macos.mkscript
@@ -85,7 +85,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -mmacosx-version-min=10.6 -arch x86_64 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 # To explain those:
 
@@ -111,5 +111,8 @@ MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -W
 #          which is a little tiresome: though it's off by default (on MacOS with -Weverything), we explicitly disable it
 #     -Wno-c11-extensions: we want to allow ourselves use of _Noreturn, a C11 annotation...
 #     -Wno-unreachable-code-return: ...which means some compilers can prove some of our return statements unnecessary
+#     -Wno-unused-but-set-variable: this is harmless, and done deliberately to avoid warnings on other compilers
+#     -Wno-declaration-after-statement: clang is very zealous about compatibility with C89 even though we are compiling in C99
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
+

--- a/Materials/platforms/macosarm.mk
+++ b/Materials/platforms/macosarm.mk
@@ -16,7 +16,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable
 

--- a/Materials/platforms/macosarm.mkscript
+++ b/Materials/platforms/macosarm.mkscript
@@ -85,7 +85,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 
 CCOPTS = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 # To explain those:
 
@@ -112,5 +112,6 @@ MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -W
 #     -Wno-c11-extensions: we want to allow ourselves use of _Noreturn, a C11 annotation...
 #     -Wno-unreachable-code-return: ...which means some compilers can prove some of our return statements unnecessary
 #     -Wno-unused-but-set-variable: this is harmless, and done deliberately to avoid warnings on other compilers
+#     -Wno-declaration-after-statement: clang is very zealous about compatibility with C89 even though we are compiling in C99
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable

--- a/Materials/platforms/macosuniv.mk
+++ b/Materials/platforms/macosuniv.mk
@@ -17,7 +17,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
 CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable
 

--- a/Materials/platforms/macosuniv.mkscript
+++ b/Materials/platforms/macosuniv.mkscript
@@ -90,7 +90,7 @@ SDKPATH := $(shell xcrun -show-sdk-path)
 CCOPTSX = -DPLATFORM_MACOS=1 -target x86_64-apple-macos10.12 -isysroot $(SDKPATH) $(CFLAGS)
 CCOPTSA = -DPLATFORM_MACOS=1 -target arm64-apple-macos11 -isysroot $(SDKPATH) $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 # To explain those:
 
@@ -117,5 +117,6 @@ MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -W
 #     -Wno-c11-extensions: we want to allow ourselves use of _Noreturn, a C11 annotation...
 #     -Wno-unreachable-code-return: ...which means some compilers can prove some of our return statements unnecessary
 #     -Wno-unused-but-set-variable: this is harmless, and done deliberately to avoid warnings on other compilers
+#     -Wno-declaration-after-statement: clang is very zealous about compatibility with C89 even though we are compiling in C99
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable


### PR DESCRIPTION
Add -Wno-declaration-after-statement. Also -Wno-unused-but-set-variable, which was missing in macos.mkscript.

I've been using "Apple clang version 14.0.3 (clang-1403.0.22.14.1)".
