### PR TITLE
initial commit readdir tweak

### DIFF
--- a/foundation-module/Chapter 1/POSIX Platforms.w
+++ b/foundation-module/Chapter 1/POSIX Platforms.w
@@ -249,7 +249,11 @@ int Platform::readdir(void *D, char *dir_name, char *leafname) {
 	int rv;
 	DIR *dirp = (DIR *) D;
 	struct dirent *dp;
-	if ((dp = readdir(dirp)) == NULL) return FALSE;
+	do {
+	  errno = 0;
+	  dp = readdir(dirp);
+	} while (errno);
+	if (dp == NULL) return FALSE;
 	sprintf(path_to, "%s%c%s", dir_name, FOLDER_SEPARATOR, dp->d_name);
 	rv = stat(path_to, &file_status);
 	if (rv != 0) return FALSE;

--- a/foundation-module/Chapter 1/POSIX Platforms.w
+++ b/foundation-module/Chapter 1/POSIX Platforms.w
@@ -250,12 +250,12 @@ int Platform::readdir(void *D, char *dir_name, char *leafname) {
 	DIR *dirp = (DIR *) D;
 	struct dirent *dp;
 	do {
-	  errno = 0;
 	  dp = readdir(dirp);
-	} while (errno);
-	if (dp == NULL) return FALSE;
-	sprintf(path_to, "%s%c%s", dir_name, FOLDER_SEPARATOR, dp->d_name);
-	rv = stat(path_to, &file_status);
+	  if (dp == NULL) return FALSE;
+	  sprintf(path_to, "%s%c%s", dir_name, FOLDER_SEPARATOR, dp->d_name);
+  	  errno = 0;
+	  rv = stat(path_to, &file_status);
+        } while (dp && (errno == ENOENT));
 	if (rv != 0) return FALSE;
 	if (S_ISDIR(file_status.st_mode)) sprintf(leafname, "%s/", dp->d_name);
 	else strcpy(leafname, dp->d_name);


### PR DESCRIPTION
Skips entries for which readdir returns errors. Both rv and errno are zero when readdir has truly run out of files, so it shouldn't infinitely loop. Probably advisable to test on Mac OS X and have someone test on Windows before merging.