### PR TITLE
Switch Windows build to MSYS2 MINGW64

### DIFF
--- a/Examples/goldbach/goldbach.mk
+++ b/Examples/goldbach/goldbach.mk
@@ -20,8 +20,6 @@ ARTOOL = libtool -o
 
 INFORM6OS = OSX
 
-GLULXEOS = OS_UNIX
-
 MYNAME = goldbach
 ME = inweb/Examples/goldbach
 

--- a/Materials/platforms/inweb-on-linux.mk
+++ b/Materials/platforms/inweb-on-linux.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = linux
 
 INFORM6OS = LINUX
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION =
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/inweb-on-macos.mk
+++ b/Materials/platforms/inweb-on-macos.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macos
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/inweb-on-macos32.mk
+++ b/Materials/platforms/inweb-on-macos32.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macos32
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/inweb-on-macosarm.mk
+++ b/Materials/platforms/inweb-on-macosarm.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macosarm
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/inweb-on-macosuniv.mk
+++ b/Materials/platforms/inweb-on-macosuniv.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macosuniv
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/inweb-on-unix.mk
+++ b/Materials/platforms/inweb-on-unix.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = unix
 
 INFORM6OS = LINUX
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest
@@ -14,7 +12,7 @@ INWEB = inweb/Tangled/inweb
 
 CCOPTS = -Wno-unused -DPLATFORM_UNIX -DUNIX64 -DCPU_WORDSIZE_MULTIPLIER=2 -O2
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/Materials/platforms/inweb-on-windows.mk
+++ b/Materials/platforms/inweb-on-windows.mk
@@ -14,7 +14,7 @@ INWEB = inweb/Tangled/inweb
 
 CCOPTS = -DPLATFORM_WINDOWS=1 -D_WIN32_WINNT=0x0600 $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -Wno-unsafe-buffer-usage -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-implicit-int-float-conversion -Wno-incompatible-function-pointer-types-strict -Wno-cast-function-type-strict -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 
@@ -69,8 +69,8 @@ safe:
 	$(call make-me-using-safety-copy)
 
 define make-me-once-tangled
-	x86_64-w64-mingw32-clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
-	x86_64-w64-mingw32-clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o 
+	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g  -o $(ME)/Tangled/$(ME).o $(ME)/Tangled/$(ME).c
+	clang $(CCOPTS) -g -o $(ME)/Tangled/$(ME)$(EXEEXTENSION) $(ME)/Tangled/$(ME).o 
 endef
 
 define make-me

--- a/Materials/platforms/inweb-on-windows.mk
+++ b/Materials/platforms/inweb-on-windows.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = windows
 
 INFORM6OS = PC_WIN32
 
-GLULXEOS = OS_WIN32
-
 EXEEXTENSION = .exe
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/linux.mk
+++ b/Materials/platforms/linux.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = linux
 
 INFORM6OS = LINUX
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION =
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/linux.mkscript
+++ b/Materials/platforms/linux.mkscript
@@ -42,11 +42,6 @@ INWEBPLATFORM = linux
 
 INFORM6OS = LINUX
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION =

--- a/Materials/platforms/macos.mk
+++ b/Materials/platforms/macos.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macos
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/macos.mkscript
+++ b/Materials/platforms/macos.mkscript
@@ -41,11 +41,6 @@ INWEBPLATFORM = macos
 
 INFORM6OS = MACOS
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = 

--- a/Materials/platforms/macos32.mk
+++ b/Materials/platforms/macos32.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macos32
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/macos32.mkscript
+++ b/Materials/platforms/macos32.mkscript
@@ -45,11 +45,6 @@ INWEBPLATFORM = macos32
 
 INFORM6OS = MACOS
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = 

--- a/Materials/platforms/macosarm.mk
+++ b/Materials/platforms/macosarm.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macosarm
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/macosarm.mkscript
+++ b/Materials/platforms/macosarm.mkscript
@@ -41,11 +41,6 @@ INWEBPLATFORM = macosarm
 
 INFORM6OS = MACOS
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = 

--- a/Materials/platforms/macosuniv.mk
+++ b/Materials/platforms/macosuniv.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = macosuniv
 
 INFORM6OS = MACOS
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/macosuniv.mkscript
+++ b/Materials/platforms/macosuniv.mkscript
@@ -41,11 +41,6 @@ INWEBPLATFORM = macosuniv
 
 INFORM6OS = MACOS
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = 

--- a/Materials/platforms/unix.mk
+++ b/Materials/platforms/unix.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = unix
 
 INFORM6OS = LINUX
 
-GLULXEOS = OS_UNIX
-
 EXEEXTENSION = 
 
 INTEST = intest/Tangled/intest
@@ -14,7 +12,7 @@ INWEB = inweb/Tangled/inweb
 
 CCOPTS = -Wno-unused -DPLATFORM_UNIX -DUNIX64 -DCPU_WORDSIZE_MULTIPLIER=2 -O2
 
-MANYWARNINGS = -Weverything -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/Materials/platforms/unix.mkscript
+++ b/Materials/platforms/unix.mkscript
@@ -41,11 +41,6 @@ INWEBPLATFORM = unix
 
 INFORM6OS = LINUX
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_UNIX
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = 

--- a/Materials/platforms/windows.mk
+++ b/Materials/platforms/windows.mk
@@ -14,7 +14,7 @@ INWEB = inweb/Tangled/inweb
 
 CCOPTS = -DPLATFORM_WINDOWS=1 -D_WIN32_WINNT=0x0600 $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -Wno-unsafe-buffer-usage -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-implicit-int-float-conversion -Wno-incompatible-function-pointer-types-strict -Wno-cast-function-type-strict -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/Materials/platforms/windows.mk
+++ b/Materials/platforms/windows.mk
@@ -5,8 +5,6 @@ INWEBPLATFORM = windows
 
 INFORM6OS = PC_WIN32
 
-GLULXEOS = OS_WIN32
-
 EXEEXTENSION = .exe
 
 INTEST = intest/Tangled/intest

--- a/Materials/platforms/windows.mkscript
+++ b/Materials/platforms/windows.mkscript
@@ -43,11 +43,6 @@ INWEBPLATFORM = windows
 
 INFORM6OS = PC_WIN32
 
-# And similarly for glulxe, which is used as part of the dumb-glulx interpreter,
-# which is used in testing Inform on the command line:
-
-GLULXEOS = OS_WIN32
-
 # On some platforms, executables have a specific file extension, which we define here:
 
 EXEEXTENSION = .exe

--- a/Materials/platforms/windows.mkscript
+++ b/Materials/platforms/windows.mkscript
@@ -66,22 +66,22 @@ INWEB = inweb/Tangled/inweb
 # and one for linking those *.o files into an executable.
 
 {define: compile to: TO from: FROM ?options: OPTS}
-	x86_64-w64-mingw32-clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
+	clang -std=c11 -c $(MANYWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
 {end-define}
 
 {define: compile-indulgently to: TO from: FROM ?options: OPTS}
-	x86_64-w64-mingw32-clang -std=c99 -c $(FEWERWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
+	clang -std=c99 -c $(FEWERWARNINGS) $(CCOPTS) -g {OPTS} -o {TO} {FROM}
 {end-define}
 
 {define: link to: TO from: FROM ?options: OPTS}
-	x86_64-w64-mingw32-clang $(CCOPTS) -g -o {TO} {FROM} {OPTS}
+	clang $(CCOPTS) -g -o {TO} {FROM} {OPTS}
 {end-define}
 
 # Where:
 
 CCOPTS = -DPLATFORM_WINDOWS=1 -D_WIN32_WINNT=0x0600 $(CFLAGS)
 
-MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -ferror-limit=1000
+MANYWARNINGS = -Weverything -Wno-unknown-warning-option -Wno-pointer-arith -Wno-unused-macros -Wno-shadow -Wno-cast-align -Wno-variadic-macros -Wno-missing-noreturn -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-missing-variable-declarations -Wno-unreachable-code-break -Wno-class-varargs -Wno-format-nonliteral -Wno-cast-qual -Wno-double-promotion -Wno-comma -Wno-strict-prototypes -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return -Wno-unused-but-set-variable -Wno-declaration-after-statement -Wno-used-but-marked-unused -Wno-unsafe-buffer-usage -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-implicit-int-float-conversion -Wno-incompatible-function-pointer-types-strict -Wno-cast-function-type-strict -ferror-limit=1000
 
 FEWERWARNINGS = -Wno-implicit-int -Wno-dangling-else -Wno-pointer-sign -Wno-format-extra-args -Wno-tautological-compare -Wno-deprecated-declarations -Wno-logical-op-parentheses -Wno-format -Wno-extra-semi-stmt -Wno-c11-extensions -Wno-unreachable-code-return
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ This will produce 32-bit x86 executables; we are no longer really supporting thi
 Macs, use macosuniv, but expect your compilation times to double, of course.
 * For a generic version of Unix where the Linux settings do not work, try using
 unix. (For Solaris, for example.)
+* For Windows, the mingw-w64 environment provided by the MSYS2 project is required.
+Download and install [MSYS2](https://www.msys2.org/). Start the MSYS2 MINGW64
+environment, then in the resulting shell window run the following to install
+everything needed:
+	* `pacman -Suy`
+	* `pacman -S git`
+	* `pacman -S make`
+	* `pacman -S zip`
+	* `pacman -S mingw-w64-x86_64-clang`
 * Android support has existed in the past, but the Android Inform community
 has not yet an opportunity to contribute build settings.
 

--- a/Tangled/inweb.c
+++ b/Tangled/inweb.c
@@ -147,7 +147,7 @@ typedef pthread_attr_t foundation_thread_attributes;
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 66 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 65 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 char *Platform__getenv(const char *name) {
 	char *env = getenv(name);
 	if (env == 0) {
@@ -166,7 +166,7 @@ char *Platform__getenv(const char *name) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 99 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 98 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 /* Check the first element of the command: if it has path separators in
    it, we assume we are running one of our commands, otherwise it is a
    Unix style command. */
@@ -236,7 +236,7 @@ int Platform__system(const char *cmd) {
 	PROCESS_INFORMATION process;
 	if (CreateProcessA(0, cmd_line, 0, 0, FALSE, CREATE_NO_WINDOW, 0, 0, &start, &process) == 0) {
 		if (unix)
-			fprintf(stderr, "A Unix-like shell \"sh\" (such as that from Cygwin) must be in the path.\n");
+			fprintf(stderr, "A Unix-like shell \"sh\" (such as that from MSYS2 or Cygwin) must be in the path.\n");
 		return -1;
 	}
 
@@ -255,7 +255,7 @@ int Platform__system(const char *cmd) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 392 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 391 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 typedef HANDLE foundation_thread;
 typedef int foundation_thread_attributes;
 
@@ -263,7 +263,7 @@ struct Win32_Thread_Start { void *(*fn)(void *); void* arg; };
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 493 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 492 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 struct Win32_Mutex { INIT_ONCE init; CRITICAL_SECTION crit; };
 
 #endif /* PLATFORM_WINDOWS */
@@ -2707,95 +2707,95 @@ int  Platform__get_core_count(void) ;
 #endif /* PLATFORM_ANDROID */
 #endif /* PLATFORM_POSIX */
 #ifdef PLATFORM_WINDOWS
-#line 47 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 46 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__Windows_isdigit(int c) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 59 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 58 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__is_folder_separator(wchar_t c) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 91 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 90 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__where_am_i(wchar_t *p, size_t length) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 188 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 187 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__mkdir(char *transcoded_pathname) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 196 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 195 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void * Platform__opendir(char *dir_name) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 201 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 200 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__readdir(void *D, char *dir_name, 	char *leafname) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 218 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 217 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__closedir(void *D) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 226 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 225 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__rename_file(char *old_transcoded_pathname, char *new_transcoded_pathname) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 232 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 231 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__rename_directory(char *old_transcoded_pathname, char *new_transcoded_pathname) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 241 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 240 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__path_add(const char* base, const char* add, char* path) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 251 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 250 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__rsync(char *transcoded_source, char *transcoded_dest) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 330 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 329 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__sleep(int seconds) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 337 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 336 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__notification(text_stream *text, int happy) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 355 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 354 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__Win32_ResetConsole(void) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 364 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 363 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__configure_terminal(void) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 406 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 405 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__create_thread(foundation_thread *pt, const foundation_thread_attributes *pa, 	void *(*fn)(void *), void *arg) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 421 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 420 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__join_thread(foundation_thread pt, void** rv) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 425 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 424 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void  Platform__init_thread(foundation_thread_attributes* pa, size_t size) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 428 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 427 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 size_t  Platform__get_thread_stack_size(foundation_thread_attributes* pa) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 438 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 437 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int  Platform__get_core_count(void) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 459 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 458 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 time_t  Platform__never_time(void) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 463 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 462 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 time_t  Platform__timestamp(char *transcoded_filename) ;
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 469 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 468 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 off_t  Platform__size(char *transcoded_filename) ;
 #endif /* PLATFORM_WINDOWS */
 #line 64 "inweb/foundation-module/Chapter 2/Debugging Log.w"
@@ -6058,21 +6058,21 @@ int Platform__get_core_count(void) {
 #ifdef PLATFORM_WINDOWS
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 47 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 46 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int Platform__Windows_isdigit(int c) {
 	return ((c >= '0') && (c <= '9')) ? 1 : 0;
 }
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 59 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 58 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int Platform__is_folder_separator(wchar_t c) {
 	return ((c == '\\') || (c == '/'));
 }
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 91 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 90 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void Platform__where_am_i(wchar_t *p, size_t length) {
 	DWORD result = GetModuleFileNameW(NULL, p, (DWORD)length);
 	if ((result == 0) || (result == length)) p[0] = 0;
@@ -6080,7 +6080,7 @@ void Platform__where_am_i(wchar_t *p, size_t length) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 188 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 187 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int Platform__mkdir(char *transcoded_pathname) {
 	errno = 0;
 	int rv = mkdir(transcoded_pathname);
@@ -6118,7 +6118,7 @@ void Platform__closedir(void *D) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 226 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 225 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int Platform__rename_file(char *old_transcoded_pathname, char *new_transcoded_pathname) {
 	if (rename(old_transcoded_pathname, new_transcoded_pathname) != 0)
 		return FALSE;
@@ -6133,7 +6133,7 @@ int Platform__rename_directory(char *old_transcoded_pathname, char *new_transcod
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 241 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 240 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void Platform__path_add(const char* base, const char* add, char* path) {
 	char last;
 
@@ -6221,20 +6221,20 @@ void Platform__rsync(char *transcoded_source, char *transcoded_dest) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 330 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 329 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void Platform__sleep(int seconds) {
 	Sleep((DWORD)(1000*seconds));
 }
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 337 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 336 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 void Platform__notification(text_stream *text, int happy) {
 }
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 348 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 347 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 #define WIN32CONS_RESET_MODE 1
 #define WIN32CONS_RESET_OUTCP 2
 
@@ -6278,7 +6278,7 @@ void Platform__configure_terminal(void) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 399 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 398 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 DWORD WINAPI Platform__Win32_Thread_Func(LPVOID param) {
 	struct Win32_Thread_Start* start = (struct Win32_Thread_Start*)param;
 	(start->fn)(start->arg);
@@ -6314,7 +6314,7 @@ size_t Platform__get_thread_stack_size(foundation_thread_attributes* pa) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 438 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 437 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 int Platform__get_core_count(void) {
 	int count = 0;
 	SYSTEM_INFO sysInfo;
@@ -6330,7 +6330,7 @@ int Platform__get_core_count(void) {
 
 #endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_WINDOWS
-#line 459 "inweb/foundation-module/Chapter 1/Windows Platform.w"
+#line 458 "inweb/foundation-module/Chapter 1/Windows Platform.w"
 time_t Platform__never_time(void) {
 	return (time_t) 0;
 }
@@ -9105,11 +9105,11 @@ int CommandLine__read_pair_p(text_stream *opt, text_stream *opt_val, int N,
 ; innocuous = TRUE; break;
 		case VERSION_CLSW: {
 			PRINT("inweb");
-			char *svn = "7.2.1-beta+1B26";
+			char *svn = "7.2.1-beta+1B27";
 			if (svn[0]) PRINT(" version %s", svn);
 			char *vname = "Escape to Danger";
 			if (vname[0]) PRINT(" '%s'", vname);
-			char *d = "9 June 2023";
+			char *d = "6 July 2023";
 			if (d[0]) PRINT(" (%s)", d);
 			PRINT("\n");
 			innocuous = TRUE; break;
@@ -33572,7 +33572,7 @@ void Ctags__write(web *W, filename *F) {
 	WRITE("!_TAG_FILE_SORTED\t0\t/0=unsorted, 1=sorted, 2=foldcase/\n");
 	WRITE("!_TAG_PROGRAM_AUTHOR\tGraham Nelson\t/graham.nelson@mod-langs.ox.ac.uk/\n");
 	WRITE("!_TAG_PROGRAM_NAME\tinweb\t//\n");
-	WRITE("!_TAG_PROGRAM_VERSION\t7.2.1-beta+1B26\t/built 9 June 2023/\n");
+	WRITE("!_TAG_PROGRAM_VERSION\t7.2.1-beta+1B27\t/built 6 July 2023/\n");
 
 }
 #line 47 "inweb/Chapter 6/Ctags Support.w"

--- a/foundation-module/Chapter 1/POSIX Platforms.w
+++ b/foundation-module/Chapter 1/POSIX Platforms.w
@@ -71,9 +71,9 @@ These settings are used for Nathan Summers's Android versions.
 #include <strings.h>
 
 @h Folder separator.
-When using a Unix-like system such as Cygwin on Windows, it's inevitable that
-paths will sometimes contain backslashes and sometimes forward slashes, meaning
-a folder (i.e. directory) divide in either case. So:
+When using a Unix-like system such as Cygwin or MSYS2 on Windows, it's
+inevitable that paths will sometimes contain backslashes and sometimes forward
+slashes, meaning a folder (i.e. directory) divide in either case. So:
 (a) When writing such a divider, always write |FOLDER_SEPARATOR|, a backslash;
 (b) When testing for such a divider, call the following.
 

--- a/foundation-module/Chapter 1/Windows Platform.w
+++ b/foundation-module/Chapter 1/Windows Platform.w
@@ -39,7 +39,6 @@ we need to consider the prototype for |isdigit()|:
 So, when casting to int we get |-23|, not |233|. Unfortunately the return value
 from |isdigit()| is only defined by the C specification for values in the
 range 0 to 255 (and also EOF), so the return value for |-23| is undefined.
-And with Windows GCC, |isdigit(-23)| returns a non-zero value.
 
 @d isdigit(x) Platform::Windows_isdigit(x)
 
@@ -49,9 +48,9 @@ int Platform::Windows_isdigit(int c) {
 }
 
 @h Folder separator.
-When using a Unix-like system such as Cygwin on Windows, it's inevitable that
-paths will sometimes contain backslashes and sometimes forward slashes, meaning
-a folder (i.e. directory) divide in either case. So:
+When using a Unix-like system such as Cygwin or MSYS2 on Windows, it's
+inevitable that paths will sometimes contain backslashes and sometimes forward
+slashes, meaning a folder (i.e. directory) divide in either case. So:
 (a) When writing such a divider, always write |FOLDER_SEPARATOR|, a backslash;
 (b) When testing for such a divider, call the following.
 
@@ -165,7 +164,7 @@ int Platform::system(const char *cmd) {
 	PROCESS_INFORMATION process;
 	if (CreateProcessA(0, cmd_line, 0, 0, FALSE, CREATE_NO_WINDOW, 0, 0, &start, &process) == 0) {
 		if (unix)
-			fprintf(stderr, "A Unix-like shell \"sh\" (such as that from Cygwin) must be in the path.\n");
+			fprintf(stderr, "A Unix-like shell \"sh\" (such as that from MSYS2 or Cygwin) must be in the path.\n");
 		return -1;
 	}
 

--- a/foundation-module/Chapter 3/Shell.w
+++ b/foundation-module/Chapter 3/Shell.w
@@ -8,7 +8,7 @@ Some of our programs have to issue commands to the host operating system,
 to copy files, pass them through TeX, and so on. All of that is done using
 the C standard library |system| function; the commands invoked are all
 standard for POSIX, so will work on MacOS and Linux, but on a Windows system
-they would need to be read in a POSIX-style environment like Cygwin.
+they would need to be read in a POSIX-style environment like Cygwin or MSYS2.
 
 =
 void Shell::quote_path(OUTPUT_STREAM, pathname *P) {

--- a/scripts/inweb.rmscript
+++ b/scripts/inweb.rmscript
@@ -72,6 +72,15 @@ This will produce 32-bit x86 executables; we are no longer really supporting thi
 Macs, use macosuniv, but expect your compilation times to double, of course.
 * For a generic version of Unix where the Linux settings do not work, try using
 unix. (For Solaris, for example.)
+* For Windows, the mingw-w64 environment provided by the MSYS2 project is required.
+Download and install [MSYS2](https://www.msys2.org/). Start the MSYS2 MINGW64
+environment, then in the resulting shell window run the following to install
+everything needed:
+	* `pacman -Suy`
+	* `pacman -S git`
+	* `pacman -S make`
+	* `pacman -S zip`
+	* `pacman -S mingw-w64-x86_64-clang`
 * Android support has existed in the past, but the Android Inform community
 has not yet an opportunity to contribute build settings.
 


### PR DESCRIPTION
In order to use clang 16, the build environment on Windows is changing from Cygwin to MSYS2. Also included is setup instructions for MSYS2.