### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/Materials/platforms/unix.mkscript
+++ b/Materials/platforms/unix.mkscript
@@ -67,7 +67,7 @@ INWEB = inweb/Tangled/inweb
 {end-define}
 
 {define: link to: TO from: FROM ?options: OPTS}
-	clang  -lm -lpthread -static -g -o {TO} {FROM} {OPTS}
+	clang  -static -g -o {TO} {FROM} {OPTS} -lm -lpthread
 {end-define}
 
 # Where:


### PR DESCRIPTION
Without this, I get
```
/usr/bin/ld: inweb/Tangled/inweb.o: in function `JSON__decode_sreq_range':
/scratch/wip/inweb/work/inweb/foundation-module/Chapter 1/POSIX Platforms.w:379: undefined reference to `pthread_create'
/usr/bin/ld: /scratch/wip/inweb/work/inweb/foundation-module/Chapter 1/POSIX Platforms.w:387: undefined reference to `pthread_attr_init'
/usr/bin/ld: /scratch/wip/inweb/work/inweb/foundation-module/Chapter 1/POSIX Platforms.w:388: undefined reference to `pthread_attr_setstacksize'
/usr/bin/ld: inweb/Tangled/inweb.o: in function `JSON__decode_req_object':
/scratch/wip/inweb/work/inweb/foundation-module/Chapter 1/POSIX Platforms.w:393: undefined reference to `pthread_attr_getstacksize'
```
