### PR TITLE
fixing orb-weaving spider url

### DIFF
--- a/Chapter 6/Colonies.w
+++ b/Chapter 6/Colonies.w
@@ -10,10 +10,8 @@ need to be cross-referenced in their woven form, so that readers can easily
 turn from one to another.
 
 [1] Those curious to see what a colony of 110,000,000 spiders might be like
-to walk through should see Albert Greene et al., "An Immense Concentration of
-Orb-Weaving Spiders With Communal Webbing in a Man-Made Structural Habitat
-(Arachnida: Araneae: Tetragnathidae, Araneidae)", American Entomologist
-(Fall 2010), at: https://www.entsoc.org/PDF/2010/Orb-weaving-spiders.pdf
+to walk through should see Albert Greene et al., //"An Immense Concentration of Orb-Weaving Spiders With Communal Webbing in a Man-Made Structural Habitat (Arachnida: Araneae: Tetragnathidae, Araneidae)" -> https://doi.org/10.1093/ae/56.3.146//,
+American Entomologist (Fall 2010).
 
 @ So, then, a colony is really just a membership list:
 


### PR DESCRIPTION
This is a fix for [Inweb-27](https://inform7.atlassian.net/browse/INWEB-27) , but just for the .w source with the link... I'm not sure I understand what the right thing to do to generate `docs/inweb/6-cln.html` is.