### PR TITLE
Fix TeX weaving.

### DIFF
--- a/literate-module/Chapter 5/TeX Format.w
+++ b/literate-module/Chapter 5/TeX Format.w
@@ -421,7 +421,8 @@ are not rendered here, they never will be.)
 
 @<Render Markdown@> =
 	weave_markdown_node *C = RETRIEVE_POINTER_weave_markdown_node(N->content);
-	MDRenderer::render_extended(OUT, (void *) trs->wv, C->content, C->variation, 0);
+	WRITE("%S", C->content);
+	//MDRenderer::render_extended(OUT, (void *) trs->wv, C->content, C->variation, 0);
 
 @<Render index@> =
 	if ((trs->wv) && (trs->wv->weave_web)) {
@@ -577,7 +578,7 @@ or DVI, only the middle one is.
 =
 void TeXWeaving::para_macro(text_stream *OUT, weave_order *wv, ls_paragraph *par, int defn) {
 	if (defn)
-		WRITE("|\\pdfdest num %d fit ",
+		WRITE("\\pdfdest num %d fit ",
 			par->allocation_id + 100);
 	else
 		WRITE("|\\pdfstartlink attr{/C [0.9 0 0] /Border [0 0 0]} goto num %d ",
@@ -589,7 +590,7 @@ void TeXWeaving::para_macro(text_stream *OUT, weave_order *wv, ls_paragraph *par
 	TeXWeaving::change_colour_PDF(OUT, PLAIN_COLOUR, FALSE);
 	WRITE("$\\rangle$ ");
 	if (defn)
-		WRITE("$\\equiv$|");
+		WRITE("$\\equiv$");
 	else
 		WRITE("\\pdfendlink|");
 }


### PR DESCRIPTION
This solves two bugs in TeX weaving mode
* The first one was calling MDRenderer for markdown nodes. In TeX weaving mode there is no colour scheme and this was causing MDRenderer to fail. Moreover MDRenderer outputs HTML which is not valid TeX code so I don't think adding the missing colout scheme is the solution.
* The second one was inserting an extra surrounding || in holon definition. I don't know what causes this behaviour, if it is the TeX template or the code but at the moment only not adding them renders as intended (at least on my machine).

It should be noted that this commit only fixes trivial stuff and allows inweb to create renderizable .tex files. TeX weaving is not working yet.